### PR TITLE
added swagger docs

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Swagger UI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.profiles.active=dev
+springdoc.swagger-ui.path=/api-docs


### PR DESCRIPTION
Small PR

Added dependency to pom.xl

```
<!-- Swagger UI -->
<dependency>
   <groupId>org.springdoc</groupId>
   <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
   <version>2.3.0</version>
</dependency>
```
Looked around the internet, found some different solutions but this is definitely the easiest I saw. referenced [here](https://springdoc.org/)


---

added one line to `application.properties`
```
springdoc.swagger-ui.path=/api-docs
```

this just makes it so you can hit `http://localhost:8080/api-docs` rather than `http:/localhost:8080/swagger-ui/index.html` although both still work


---

![image](https://github.com/nickerick/skill-magnet/assets/72476187/bb54a63f-6ddc-4e4e-bc1e-345642c779fe)
