### PR TITLE
Create Dummy Data Generation Script for Server

### DIFF
--- a/server/src/main/java/com/skillmagnet/DataInitializer.java
+++ b/server/src/main/java/com/skillmagnet/DataInitializer.java
@@ -1,0 +1,83 @@
+package com.skillmagnet;
+
+import com.skillmagnet.Course.Course;
+import com.skillmagnet.Course.CourseRepository;
+import com.skillmagnet.Enrolls.Enrolls;
+import com.skillmagnet.Enrolls.EnrollsRepository;
+import com.skillmagnet.Lesson.Lesson;
+import com.skillmagnet.Lesson.LessonRepository;
+import com.skillmagnet.Lesson.VideoType;
+import com.skillmagnet.User.User;
+import com.skillmagnet.User.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private LessonRepository lessonRepository;
+
+    @Autowired
+    private EnrollsRepository enrollsRepository;
+
+    @Value("${data.generation.enabled:false}")
+    private boolean dataGenerationEnabled;
+
+    @Override
+    public void run(String[] args) {
+        if (dataGenerationEnabled) {
+            System.out.println("Generating data...");
+
+
+            // Create Users
+            User user1 = new User("Test User", "password");
+            userRepository.save(user1);
+
+            User user2 = new User("John Doe", "Tigers2!");
+            userRepository.save(user2);
+
+
+            // Create Course and Lessons
+            Course course1 = new Course();
+            course1.setTitle("Python 101");
+            course1.setDescription("Learn Python for complete beginners!");
+            course1.setCategory("Programming");
+            courseRepository.save(course1);
+
+            Lesson lesson1 = new Lesson();
+            lesson1.setTitle("Overview");
+            lesson1.setVideoType(VideoType.SELF_HOSTED);
+            lesson1.setVideoNumber(1);
+            lesson1.setCourse(course1);
+            lessonRepository.save(lesson1);
+
+            Lesson lesson2 = new Lesson();
+            lesson2.setTitle("Hello, World");
+            lesson2.setVideoType(VideoType.YOUTUBE);
+            lesson2.setVideoNumber(2);
+            lesson2.setCourse(course1);
+            lessonRepository.save(lesson2);
+
+
+            // Enroll 'Test User' into course 'Python 101'
+            Enrolls enrollment1 = new Enrolls();
+            enrollment1.setEnrolledUser(user1);
+            enrollment1.setEnrolledCourse(course1);
+            enrollsRepository.save(enrollment1);
+
+
+            System.out.println("Finished generating data.");
+        } else {
+            System.out.println("Data generation is disabled.");
+        }
+    }
+}

--- a/server/src/main/resources/application-dbpop.properties
+++ b/server/src/main/resources/application-dbpop.properties
@@ -1,0 +1,2 @@
+data.generation.enabled=true
+spring.jpa.hibernate.ddl-auto=create

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,2 +1,6 @@
+# Append dbpop to generate data into SQL tables
+#
+# Example: spring.profiles.active=dev,dbpop
+# Note: Drops all tables and reinserts dummy on every startup when active.
 spring.profiles.active=dev
 springdoc.swagger-ui.path=/api-docs


### PR DESCRIPTION
## Issue
Client team wanted dummy data for the database for their testing and development. 

## Solution
Created a script that will create all the models of the application so that all endpoints will function out of the box.

Script can be toggled in the `application.properties` by adding the `dbpop` profile to the active list.
Example: `spring.profiles.active=dev,dbpop`
